### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Hiit-Fit
 
-## My own app to manage and pace my Tabata (Hiit) routines and a ticker Clock to keep rythm of heavy weight training
+## My own app to manage and pace my Tabata (Hiit) routines and a ticker Clock to keep rhythm of heavy weight training
 
 ### Run in dev: pnpm dev


### PR DESCRIPTION
## Summary
- correct typo in README

## Testing
- `pnpm lint` *(fails: Unexpected any, specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_6897973fd0e88320b91c0bfa39a47965