### PR TITLE
Reset temporary exercise id on cancel

### DIFF
--- a/src/components/edit-routines.tsx
+++ b/src/components/edit-routines.tsx
@@ -127,6 +127,7 @@ export default function EditRoutine({
     resetField("newExercise.name")
     resetField("newExercise.restTime")
     resetField("newExercise.duration")
+    resetField("newExercise.id")
   }
 
   const onSubmit = (data: RoutineFormValues) => {


### PR DESCRIPTION
## Summary
- Reset temporary exercise ID when cancelling an edit so all temporary fields are cleared

## Testing
- `pnpm lint` *(fails: Unexpected any in Input.tsx and NumberInput.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68979610f58883208cfa3b5bb64f6776