### PR TITLE
chore: clarify hook import comment

### DIFF
--- a/src/components/edit-routines.tsx
+++ b/src/components/edit-routines.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useState, useEffect, useMemo } from "react" // Changed useEffect to useMemo
+import { useState, useEffect, useMemo } from "react"
+// useEffect sets initial readiness; useMemo memoizes default values
 import { useForm, useFieldArray } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { routineSchema, RoutineFormValues } from "@/lib/validationSchemas"


### PR DESCRIPTION
## Summary
- clarify why `useEffect` and `useMemo` are imported in `edit-routines`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any)


------
https://chatgpt.com/codex/tasks/task_e_6897949fec4883208e65f9e846cc03d0