### PR TITLE
feat: add Prisma schema and services

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,3 @@
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE"
+SUPABASE_URL="https://your-project.supabase.co"
+SUPABASE_ANON_KEY="your-anon-key"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local
 
 # vercel
 .vercel

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,33 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum Dificultad {
+  facil
+  media
+  dificil
+}
+
+model Routine {
+  id          Int        @id @default(autoincrement())
+  name        String
+  descripcion String?
+  dificultad  Dificultad
+  creadoEn    DateTime   @default(now())
+  exercises   Exercise[]
+}
+
+model Exercise {
+  id        Int      @id @default(autoincrement())
+  name      String
+  duration  Int
+  rest      Int      @default(0)
+  link      String?
+  routine   Routine? @relation(fields: [routineId], references: [id])
+  routineId Int?
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from '@prisma/client'
+
+// Reuse Prisma client across hot reloads in development
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
+
+const prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+
+export default prisma

--- a/src/services/exerciseService.ts
+++ b/src/services/exerciseService.ts
@@ -1,0 +1,38 @@
+import prisma from '@/lib/prisma'
+
+// Create a new exercise
+export async function createExercise(data: {
+  name: string
+  duration: number
+  rest?: number
+  link?: string
+  routineId?: number
+}) {
+  return prisma.exercise.create({
+    data,
+  })
+}
+
+// Delete an exercise by id
+export async function deleteExercise(id: number) {
+  return prisma.exercise.delete({
+    where: { id },
+  })
+}
+
+// Update exercise fields
+export async function updateExercise(
+  id: number,
+  data: {
+    name?: string
+    duration?: number
+    rest?: number
+    link?: string
+    routineId?: number
+  }
+) {
+  return prisma.exercise.update({
+    where: { id },
+    data,
+  })
+}

--- a/src/services/routineService.ts
+++ b/src/services/routineService.ts
@@ -1,0 +1,51 @@
+import prisma from '@/lib/prisma'
+import { Dificultad } from '@prisma/client'
+
+// Create a new routine
+export async function createRoutine(data: {
+  name: string
+  descripcion?: string
+  dificultad: Dificultad
+  exerciseIds?: number[]
+}) {
+  return prisma.routine.create({
+    data: {
+      name: data.name,
+      descripcion: data.descripcion,
+      dificultad: data.dificultad,
+      exercises: data.exerciseIds
+        ? { connect: data.exerciseIds.map(id => ({ id })) }
+        : undefined,
+    },
+  })
+}
+
+// Delete a routine by id
+export async function deleteRoutine(id: number) {
+  return prisma.routine.delete({
+    where: { id },
+  })
+}
+
+// Update routine fields
+export async function updateRoutine(
+  id: number,
+  data: {
+    name?: string
+    descripcion?: string
+    dificultad?: Dificultad
+    exerciseIds?: number[]
+  }
+) {
+  return prisma.routine.update({
+    where: { id },
+    data: {
+      name: data.name,
+      descripcion: data.descripcion,
+      dificultad: data.dificultad,
+      exercises: data.exerciseIds
+        ? { set: data.exerciseIds.map(id => ({ id })) }
+        : undefined,
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- configure Prisma with environment variables and Supabase connection
- add Prisma schema and service functions for routines and exercises

## Testing
- `pnpm lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68964a8916308320bafb5f19f083ac78