### PR TITLE
Rename difficulty enum

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,19 +7,20 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-enum Dificultad {
-  facil
-  media
-  dificil
+enum Difficulty_Level {
+  easy
+  intermediate
+  hard
+  expert
 }
 
 model Routine {
-  id          Int        @id @default(autoincrement())
-  name        String
-  descripcion String?
-  dificultad  Dificultad
-  creadoEn    DateTime   @default(now())
-  exercises   Exercise[]
+  id             Int             @id @default(autoincrement())
+  name           String
+  descripcion    String?
+  difficultyLevel Difficulty_Level
+  creadoEn       DateTime        @default(now())
+  exercises      Exercise[]
 }
 
 model Exercise {

--- a/src/services/routineService.ts
+++ b/src/services/routineService.ts
@@ -1,18 +1,18 @@
 import prisma from '@/lib/prisma'
-import { Dificultad } from '@prisma/client'
+import { Difficulty_Level } from '@prisma/client'
 
 // Create a new routine
 export async function createRoutine(data: {
   name: string
   descripcion?: string
-  dificultad: Dificultad
+  difficultyLevel: Difficulty_Level
   exerciseIds?: number[]
 }) {
   return prisma.routine.create({
     data: {
       name: data.name,
       descripcion: data.descripcion,
-      dificultad: data.dificultad,
+      difficultyLevel: data.difficultyLevel,
       exercises: data.exerciseIds
         ? { connect: data.exerciseIds.map(id => ({ id })) }
         : undefined,
@@ -33,7 +33,7 @@ export async function updateRoutine(
   data: {
     name?: string
     descripcion?: string
-    dificultad?: Dificultad
+    difficultyLevel?: Difficulty_Level
     exerciseIds?: number[]
   }
 ) {
@@ -42,7 +42,7 @@ export async function updateRoutine(
     data: {
       name: data.name,
       descripcion: data.descripcion,
-      dificultad: data.dificultad,
+      difficultyLevel: data.difficultyLevel,
       exercises: data.exerciseIds
         ? { set: data.exerciseIds.map(id => ({ id })) }
         : undefined,


### PR DESCRIPTION
## Summary
- rename difficulty enum and routine field to `Difficulty_Level`
- update routine service to use `difficultyLevel`

## Testing
- `npx prisma generate`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b129ecc88320a6b10539e5440e40